### PR TITLE
postgres: recreate view: DROP instead or CREATE OR REPLACE

### DIFF
--- a/Dia/SQL/Dialect/PostgreSQL/Wish/views.pm
+++ b/Dia/SQL/Dialect/PostgreSQL/Wish/views.pm
@@ -5,9 +5,11 @@ sub wish_to_actually_create_views {
 	my ($items, $options) = @_;
 	
 	foreach my $i (@$items) {
-	
-		sql_do ("CREATE OR REPLACE VIEW $i->{name} ($i->{columns}) AS $i->{sql}");
-		
+
+		sql_do ("DROP VIEW IF EXISTS $i->{name}");
+
+		sql_do ("CREATE VIEW $i->{name} ($i->{columns}) AS $i->{sql}");
+
 	}
 
 }


### PR DESCRIPTION
При CREATE OR REPLACE
The new query must generate the same columns that were generated by the existing view query (that is, the same column names in the same order and with the same data types), but it may add additional columns to the end of the list. 
Соответственно, внесение в запрос, создающий VIEW, изменений, не учитывающих эту особенность, приводит к ошибкам при пересоздании модели.