### PR TITLE
sql: do not add auto alias when cte

### DIFF
--- a/Dia/SQL/TheSqlFunction.pm
+++ b/Dia/SQL/TheSqlFunction.pm
@@ -39,7 +39,8 @@ sub _sql_list_fields {
 	my $level    = 0;
 	my $is_group = 0;
 	my $has_placeholder = 0;
-		
+	my $is_no_auto_alias = $src =~ /\bRECURSIVE\b/;
+
 	foreach my $token ("$src," =~ m((
 	
 		'.*?(?:(?:''){1,}'|(?<!['\\])'(?!')|\\'{2})
@@ -74,7 +75,7 @@ sub _sql_list_fields {
 		
 		}
 		
-		if ($token =~ /^[a-z][a-z_\d]*$/) {
+		if ($token =~ /^[a-z][a-z_\d]*$/ && !$is_no_auto_alias) {
 
 			$buffer .= $table_alias . '.' . sql_field_name ($token);   next;
 


### PR DESCRIPTION
consider
`["orgs.id IN (WITH RECURSIVE cte AS ...)" => [@params]],`
output (wrong)
```orgs.id IN (WITH RECURSIVE orgs.cte AS ...```
output (tobe)
```orgs.id IN (WITH RECURSIVE cte AS ...```