### PR TITLE
no_model_update Can't call method "assert" on unblessed reference FIX

### DIFF
--- a/Dia/Content/ModuleTools.pm
+++ b/Dia/Content/ModuleTools.pm
@@ -235,7 +235,7 @@ sub require_scripts {
 	
 	my @dirs = grep {-d} _INC ();
 	
-	require_model_scripts (@dirs);
+	$preconf -> {no_model_update} or require_model_scripts (@dirs);
 	
 	require_update_scripts ($_) foreach (@dirs);
 		


### PR DESCRIPTION
elud.json
```
"no_model_update": 1,
```
error.log
```
$VAR1 = {
          'model_update' => {
                              'core_ok' => 1
                            }
        };
Can't call method "assert" on unblessed reference at /var/projects/dia/Dia/Content/ModuleTools.pm line 110.
 at /var/projects/dia/Dia/Content/ModuleTools.pm line 110.
        APP::require_model_scripts("/var/projects/dia/Dia/GenericApplication", "/var/projects/energy_gisee/back/lib") called at /var/projects/dia/Dia/Content/ModuleTools.pm line 238
        APP::require_scripts() called at /var/projects/dia/Dia/Content/ModuleTools.pm line 66
        APP::require_model() called at /var/projects/dia/Dia/Server/fork.pm line 161
        main::start() called at -e line 1
```