### PR TITLE
table_keys: allowed spaces in indexes parts

### DIFF
--- a/Dia/SQL/Dialect/PostgreSQL/Wish/table_keys.pm
+++ b/Dia/SQL/Dialect/PostgreSQL/Wish/table_keys.pm
@@ -30,16 +30,16 @@ sub wish_to_clarify_demands_for_table_keys {
 
 		}
 
-		$i -> {parts} = [split /\,/, $i -> {parts}];
+		$i -> {parts} = [split /\s*\,\s*/, $i -> {parts}];
 
 	}
 
 	foreach my $part (@{$i -> {parts}}) {
 	
 		$part = lc $part;
+
+		$part =~ s{^\s+|\s+$}{}gsm;
 		
-		$part =~ s{\s}{}gsm;
-	
 		$part =~ s{(\w+)\((\d+)\)}{substring($1 from 1 for $2)};
 
 	}


### PR DESCRIPTION
при создании составных индексов отдельные поля теперь - всё, что разделено запятой И пробелами, пробелы внутри одной из частей индекса допустимы
необходимо для создания индексов типа
`dt_receipt => 'dt_receipt DESC NULLS LAST, dt_letter ASC NULLS FIRST'`