### PR TITLE
TheSqlFunction: do not add NULLS LAST to root table PK for PostgreSQL

### DIFF
--- a/Dia/SQL/TheSqlFunction.pm
+++ b/Dia/SQL/TheSqlFunction.pm
@@ -982,7 +982,7 @@ sub sql {
 		
 		$order =~ s{(?<!\.)\b([a-z][a-z0-9_]*)\b(?!\.)}{(grep {$_ -> {alias} eq $1} @{$columns_by_grouping -> [1]}) > 0 ? $1 : "${root}.$1"}gsme;
 				
-		$order =~ s{\bDESC\b}{DESC NULLS LAST}g if ($SQL_VERSION -> {driver} eq 'PostgreSQL');
+		$order =~ s{(?<!$root\.id\s)\bDESC\b}{DESC NULLS LAST}g if ($SQL_VERSION -> {driver} eq 'PostgreSQL');
 		
 		$sql .= "\nORDER BY\n $order";
 


### PR DESCRIPTION
Если ORDER BY строится по id корневой таблицы, то не добавлять NULLS LAST к DESC. Postgres строит планы запроса неоптимально, что приводит долгим запросам на средних и больших таблицах.
[explain.txt](https://github.com/do-/dia.pm/files/11849745/explain.txt)

