### PR TITLE
Handler: get request content-type from cgi params

### DIFF
--- a/Dia/Content/Handler.pm
+++ b/Dia/Content/Handler.pm
@@ -58,7 +58,7 @@ sub get_request_problem {
 
 	$ENV {REQUEST_METHOD} eq 'POST' or return 405;
 
-	my $enctype = $r -> {Q} -> http ('Content-Type');
+	my $enctype = $r -> {Q} -> content_type();
 
 	my $enctype_handlers = {
 		'application/json' => {


### PR DESCRIPTION
https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#10.1.1-pass-header
Note that the headers "Content-type" and "Content-length" are never passed to
the FastCGI application because they are already converted into parameters.

Метод получения Content-Type изменён на
https://metacpan.org/pod/CGI::Simple#content_type()-Get-the-content_type-of-data-submitted-in-a-POST