### PR TITLE
Replacing of obsolete pg_attrdef.adsrc column

### DIFF
--- a/Dia/SQL/Dialect/PostgreSQL/Wish/table_columns.pm
+++ b/Dia/SQL/Dialect/PostgreSQL/Wish/table_columns.pm
@@ -109,7 +109,7 @@ sub wish_to_explore_existing_table_columns {
 			SELECT 
 				pg_attribute.*
 				, pg_type.typname
-				, pg_attrdef.adsrc
+				, pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) adsrc
 				, pg_description.description
 				, pg_class.relname
 				, CASE atttypid


### PR DESCRIPTION
Устаревшая колонка была удалена из 12 версии PostgreSQL, проверил запрос с pg_get_expr(adbin, adrelid) на версиях 9.6, 10, 13, 15.

https://www.postgresql.org/docs/12/release-12.html

This column has been deprecated for a long time, because it did not update in response to other catalog changes (such as column renamings). The recommended way to get a text version of a default-value expression from pg_attrdef is pg_get_expr(adbin, adrelid).